### PR TITLE
Minor fixes after ND/FD split

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(appfwk REQUIRED)
 find_package(opmonlib REQUIRED)
 find_package(readoutmodules REQUIRED)
 find_package(ndreadoutlibs REQUIRED)
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost COMPONENTS iostreams unit_test_framework REQUIRED)
 
 ##############################################################################
 
@@ -50,7 +50,7 @@ daq_add_python_bindings(*.cpp LINK_LIBRARIES ${PROJECT_NAME} ) # Any additional 
 
 # See https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/#daq_add_plugin
 
-daq_add_plugin(NDDataLinkHandler duneDAQModule LINK_LIBRARIES appfwk::appfwk readoutmodules::readoutmodules ndreadoutlibs::ndreadoutlibs) # Replace appfwk library with a more specific library when appropriate
+daq_add_plugin(NDDataLinkHandler duneDAQModule LINK_LIBRARIES appfwk::appfwk readoutmodules::readoutmodules ndreadoutlibs::ndreadoutlibs Boost::iostreams) # Replace appfwk library with a more specific library when appropriate
 
 ##############################################################################
 

--- a/plugins/NDDataLinkHandler.cpp
+++ b/plugins/NDDataLinkHandler.cpp
@@ -70,7 +70,7 @@ NDDataLinkHandler::get_info(opmonlib::InfoCollector& ci, int level)
 }
 
 std::unique_ptr<readoutlibs::ReadoutConcept>
-NDDataLinkHandlercreate_readout(const nlohmann::json& args, std::atomic<bool>& run_marker)
+NDDataLinkHandler::create_readout(const nlohmann::json& args, std::atomic<bool>& run_marker)
 {
   namespace rol = dunedaq::readoutlibs;
   namespace ndt = dunedaq::ndreadoutlibs::types;

--- a/plugins/NDDataLinkHandler.hpp
+++ b/plugins/NDDataLinkHandler.hpp
@@ -18,7 +18,7 @@ namespace dunedaq {
 namespace ndreadoutmodules {
 
 class NDDataLinkHandler : public dunedaq::appfwk::DAQModule,
-                          private dunedaq::readoutmodules::DataLinkHandlerBase
+                          public dunedaq::readoutmodules::DataLinkHandlerBase
 {
 public:
   using inherited_dlh = dunedaq::readoutmodules::DataLinkHandlerBase;


### PR DESCRIPTION
The minor changes were fixing a typo, switching from private inheritance to public inheritance for DataLinkHandlerBase, and adding a dependency on Boost::iostreams so that the NDDataLinkHandler plugin has the necessary access to zlib library functions at runtime.