### PR TITLE
DAQ conf split documentation change

### DIFF
--- a/scripts/ndreadoutmodules_gen
+++ b/scripts/ndreadoutmodules_gen
@@ -41,7 +41,7 @@ def cli(config, json_dir):
 
     console.log(f"\nIndividual configuration records before any command line overrides: ")    
 
-    # Copy-of-a-hack, see daqconf's daqconf_multiru_gen file (commit e26a21d54fc5)
+    # Copy-of-a-hack, see daqconf's nddaqconf_gen file (commit e26a21d54fc5)
     boot = daqconfgen.boot(**config_data.boot)
     console.log(f"boot configuration object: {boot.pod()}")
 


### PR DESCRIPTION
This pull request addresses the need to have a daqconf for fd and nd separately. This pull request is associated to a number of pull requests: 
- daqconf: https://github.com/DUNE-DAQ/daqconf/pull/386
- nddaqconf: https://github.com/DUNE-DAQ/nddaqconf/pull/3
- fddaqconf: https://github.com/DUNE-DAQ/fddaqconf/pull/1
- lbrulibs: https://github.com/DUNE-DAQ/lbrulibs/pull/62
- daq-systemtest: https://github.com/DUNE-DAQ/daq-systemtest/pull/64
- dfmodules: https://github.com/DUNE-DAQ/dfmodules/pull/313
- ndreadoutmodules: https://github.com/DUNE-DAQ/ndreadoutmodules/pull/5

You can find the associated issue in https://github.com/DUNE-DAQ/daq-deliverables/issues/119
and the deliverable documentation https://github.com/DUNE-DAQ/daq-deliverables/blob/feature/fddaq_v4.2.0_dev/docs/fddaq-v4.2.0/daqconfSplitForNDFD.md